### PR TITLE
Modification of Thread Error

### DIFF
--- a/cassinyspawner/swarmspawner.py
+++ b/cassinyspawner/swarmspawner.py
@@ -41,7 +41,7 @@ class SwarmSpawner(Spawner):
     _executor = None
 
     @property
-    def executor(self, max_workers=None):
+    def executor(self, max_workers=1):
         """single global executor"""
         cls = self.__class__
         if cls._executor is None:


### PR DESCRIPTION

## Environment

* CentOS 7.2
* Docker 1.13
* Python 3.4.5

## Error

```
[E 2017-02-25 09:28:04.243 JupyterHub app:1527]                     [1/599]
    Traceback (most recent call last):
      File "/usr/lib/python3.4/site-packages/jupyterhub/app.py", line 1524, in launch_instance_async
        yield self.initialize(argv)
      File "/usr/lib/python3.4/site-packages/jupyterhub/app.py", line 1315, in initialize
        yield self.init_spawners()
      File "/usr/lib/python3.4/site-packages/jupyterhub/app.py", line 1087, in init_spawners
        status = yield spawner.poll()
      File "/usr/lib/python3.4/site-packages/swarmspawner-0.1-py3.4.egg/cassinyspawner/swarmspawner.py", line 219, in poll
        service = yield self.get_service()
      File "/usr/lib/python3.4/site-packages/swarmspawner-0.1-py3.4.egg/cassinyspawner/swarmspawner.py", line 255, in get_service
        'inspect_service', self.service_name
      File "/usr/lib/python3.4/site-packages/swarmspawner-0.1-py3.4.egg/cassinyspawner/swarmspawner.py", line 214, in docker
        return self.executor.submit(self._docker, method, *args, **kwargs)
      File "/usr/lib64/python3.4/concurrent/futures/thread.py", line 105, in submit
        self._adjust_thread_count()
      File "/usr/lib64/python3.4/concurrent/futures/thread.py", line 116, in _adjust_thread_count
        if len(self._threads) < self._max_workers:
    TypeError: unorderable types: int() < NoneType()
```
